### PR TITLE
Updated requirements.txt to use specific library versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,18 @@
-numpy
-rouge_score
-fire
-openai
-transformers>=4.31.0
-torch>=2.0
+numpy==1.26.0
+rouge_score==0.1.2
+fire==0.5.0
+# openai
+transformers==4.34.0
+torch==2.0.0
 sentencepiece
-tokenizers>=0.13.3
-wandb
-accelerate
-datasets
-deepspeed
-peft
-partial
-gradio
-einops
-bitsandbytes
-scipy
+tokenizers==0.14.0
+# wandb
+accelerate==0.23.0
+datasets==2.14.5
+deepspeed==0.10.3
+peft==0.5.0
+# partial
+# gradio
+einops==0.7.0
+bitsandbytes==0.41.1
+scipy==1.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ fire==0.5.0
 # openai
 transformers==4.34.0
 torch==2.0.0
-sentencepiece
+sentencepiece==0.1.99
 tokenizers==0.14.0
 # wandb
 accelerate==0.23.0
@@ -16,3 +16,4 @@ peft==0.5.0
 einops==0.7.0
 bitsandbytes==0.41.1
 scipy==1.11.3
+protobuf==4.24.4


### PR DESCRIPTION
@yukang2017 Hello Yukang,  I have fixed the library versions in requirements.txt and commented out the libraries that are not used. I have tested it by running supervised-fine-tune-qlora.py, which does not need upcast_layer_for_flash_attention any more(The previous [pull request](https://github.com/dvlab-research/LongLoRA/pull/101) needing it might be because of library version difference).

The test branch I used is here - https://github.com/weicheng113/LongLoRA/tree/experiment. Please have a review of the pull request. If there is any problem, please let me know. 

Thanks,
Cheng