### PR TITLE
[add] support for full-attention gptneox

### DIFF
--- a/fine-tune.py
+++ b/fine-tune.py
@@ -55,6 +55,10 @@ class TrainingArguments(transformers.TrainingArguments):
         default=True,
         metadata={"help": "Whether use flash attention for training."},
     )
+    use_full_attn: bool = field(
+        default=False,
+        metadata={"help": "Whether to use plain, full-attention for training."},
+    )
     low_rank_training: bool = field(
         default=True,
         metadata={"help": "Whether use low rank adaptation for training."},
@@ -103,10 +107,10 @@ def train():
 
     # NOTE: May expand supported model types in the future
     if model_args.model_type == "gpt-neox":
-        replace_gpt_neox_attn(training_args.use_flash_attn) 
+        replace_gpt_neox_attn(training_args.use_flash_attn, training_args.use_full_attn) 
     else:
         assert model_args.model_type == "llama", "Only support llama and gpt-neox for now"
-        replace_llama_attn(training_args.use_flash_attn)
+        replace_llama_attn(training_args.use_flash_attn, training_args.use_full_attn)
 
     # Set RoPE scaling factor
     config = transformers.AutoConfig.from_pretrained(

--- a/supervised-fine-tune-qlora.py
+++ b/supervised-fine-tune-qlora.py
@@ -87,6 +87,10 @@ class TrainingArguments(transformers.TrainingArguments):
         default=True,
         metadata={"help": "Whether use flash attention for training."},
     )
+    use_full_attn: bool = field(
+        default=False,
+        metadata={"help": "Whether to use plain, full-attention for training."},
+    )
     low_rank_training: bool = field(
         default=True,
         metadata={"help": "Whether use low rank adaptation for training."},
@@ -224,9 +228,9 @@ def train():
 
     # NOTE: May expand supported model types in the future
     if model_args.model_type == "gpt-neox":
-        replace_gpt_neox_attn(training_args.use_flash_attn) 
+        replace_gpt_neox_attn(training_args.use_flash_attn, training_args.use_full_attn) 
     else:
-        replace_llama_attn(training_args.use_flash_attn)
+        replace_llama_attn(training_args.use_flash_attn, training_args.use_full_attn)
 
     # Set RoPE scaling factor
     config = transformers.AutoConfig.from_pretrained(

--- a/supervised-fine-tune.py
+++ b/supervised-fine-tune.py
@@ -86,6 +86,10 @@ class TrainingArguments(transformers.TrainingArguments):
         default=True,
         metadata={"help": "Whether use flash attention for training."},
     )
+    use_full_attn: bool = field(
+        default=False,
+        metadata={"help": "Whether to use plain, full-attention for training."},
+    )
     low_rank_training: bool = field(
         default=True,
         metadata={"help": "Whether use low rank adaptation for training."},
@@ -223,9 +227,9 @@ def train():
 
     # NOTE: May expand supported model types in the future
     if model_args.model_type == "gpt-neox":
-        replace_gpt_neox_attn(training_args.use_flash_attn) 
+        replace_gpt_neox_attn(training_args.use_flash_attn, training_args.use_full_attn) 
     else:
-        replace_llama_attn(training_args.use_flash_attn)
+        replace_llama_attn(training_args.use_flash_attn, training_args.use_full_attn)
 
     # Set RoPE scaling factor
     config = transformers.AutoConfig.from_pretrained(


### PR DESCRIPTION
When the code is run with options
- `use flash attention`: True
- `use full attention`: True
Would result in tensor shape mismatch error in flash attention.

This commit is a fix for the `use_full = True` when using flash attention for GPTNeoX models.
Prior code was steered towards only support with the short-shift(SS) attention.
