### PR TITLE
Added management of rope factor in previous configuration

### DIFF
--- a/fine-tune.py
+++ b/fine-tune.py
@@ -118,10 +118,14 @@ def train():
         cache_dir=training_args.cache_dir,
     )
 
+    orig_rope_scaling = getattr(config, "rope_scaling",  {"factor": 1})
+    orig_rope_scaling_factor = orig_rope_scaling["factor"] if "factor" in orig_rope_scaling.keys() else 1
     orig_ctx_len = getattr(config, "max_position_embeddings", None)
-    if orig_ctx_len and training_args.model_max_length > orig_ctx_len:
-        scaling_factor = float(math.ceil(training_args.model_max_length / orig_ctx_len))
-        config.rope_scaling = {"type": "linear", "factor": scaling_factor}
+    if orig_ctx_len:
+        orig_ctx_len *= orig_rope_scaling_factor
+        if training_args.model_max_length > orig_ctx_len:
+            scaling_factor = float(math.ceil(training_args.model_max_length / orig_ctx_len))
+            config.rope_scaling = {"type": "linear", "factor": scaling_factor}
 
     # Load model and tokenizer
     model = transformers.AutoModelForCausalLM.from_pretrained(

--- a/supervised-fine-tune-qlora.py
+++ b/supervised-fine-tune-qlora.py
@@ -252,8 +252,9 @@ def train():
     orig_ctx_len = getattr(config, "max_position_embeddings", None)
     if orig_ctx_len:
         orig_ctx_len *= orig_rope_scaling_factor
-        scaling_factor = float(math.ceil(training_args.model_max_length / orig_ctx_len))
-        config.rope_scaling = {"type": "linear", "factor": scaling_factor}
+        if training_args.model_max_length > orig_ctx_len:
+            scaling_factor = float(math.ceil(training_args.model_max_length / orig_ctx_len))
+            config.rope_scaling = {"type": "linear", "factor": scaling_factor}
 
     # Load model and tokenizer
     model = transformers.AutoModelForCausalLM.from_pretrained(

--- a/supervised-fine-tune-qlora.py
+++ b/supervised-fine-tune-qlora.py
@@ -247,8 +247,11 @@ def train():
         cache_dir=training_args.cache_dir,
     )
 
+    orig_rope_scaling = getattr(config, "rope_scaling",  {"factor": 1})
+    orig_rope_scaling_factor = orig_rope_scaling["factor"] if "factor" in orig_rope_scaling.keys() else 1
     orig_ctx_len = getattr(config, "max_position_embeddings", None)
-    if orig_ctx_len and training_args.model_max_length > orig_ctx_len:
+    if orig_ctx_len:
+        orig_ctx_len *= orig_rope_scaling_factor
         scaling_factor = float(math.ceil(training_args.model_max_length / orig_ctx_len))
         config.rope_scaling = {"type": "linear", "factor": scaling_factor}
 

--- a/supervised-fine-tune.py
+++ b/supervised-fine-tune.py
@@ -251,8 +251,9 @@ def train():
     orig_ctx_len = getattr(config, "max_position_embeddings", None)
     if orig_ctx_len:
         orig_ctx_len *= orig_rope_scaling_factor
-        scaling_factor = float(math.ceil(training_args.model_max_length / orig_ctx_len))
-        config.rope_scaling = {"type": "linear", "factor": scaling_factor}
+        if training_args.model_max_length > orig_ctx_len:
+            scaling_factor = float(math.ceil(training_args.model_max_length / orig_ctx_len))
+            config.rope_scaling = {"type": "linear", "factor": scaling_factor}
 
     # Load model and tokenizer
     model = transformers.AutoModelForCausalLM.from_pretrained(

--- a/supervised-fine-tune.py
+++ b/supervised-fine-tune.py
@@ -246,8 +246,11 @@ def train():
         cache_dir=training_args.cache_dir,
     )
 
+    orig_rope_scaling = getattr(config, "rope_scaling",  {"factor": 1})
+    orig_rope_scaling_factor = orig_rope_scaling["factor"] if "factor" in orig_rope_scaling.keys() else 1
     orig_ctx_len = getattr(config, "max_position_embeddings", None)
-    if orig_ctx_len and training_args.model_max_length > orig_ctx_len:
+    if orig_ctx_len:
+        orig_ctx_len *= orig_rope_scaling_factor
         scaling_factor = float(math.ceil(training_args.model_max_length / orig_ctx_len))
         config.rope_scaling = {"type": "linear", "factor": scaling_factor}
 


### PR DESCRIPTION
Based on closed issue #81 I added some sones to take care of rope scaling factor already present in the model configuration, as it can be easily missed otherwise. I may suggest to add a small note on this also in training section of the the README file .